### PR TITLE
use SecureRandom.getInstanceStrong and lower Argon2 parameters

### DIFF
--- a/src/main/java/interface_adapter/crypto/key_generator/Argon2KeyGenerator.java
+++ b/src/main/java/interface_adapter/crypto/key_generator/Argon2KeyGenerator.java
@@ -7,7 +7,7 @@ public class Argon2KeyGenerator implements KeyGenerator {
     private static final int ARGON2_VERSION = Argon2Parameters.ARGON2_VERSION_13;
     private static final int ARGON2_TYPE = Argon2Parameters.ARGON2_d;
     private static final int ARGON2_ITERATIONS = 4;
-    private static final int ARGON2_MEM_AS_KB = 1048576;
+    private static final int ARGON2_MEM_AS_KB = 262144;
     private static final int ARGON2_PARALLELISM = 4;
 
     private static Argon2Parameters getParameters(byte[] salt) {

--- a/src/main/java/interface_adapter/crypto/random_generator/SecureRandomGenerator.java
+++ b/src/main/java/interface_adapter/crypto/random_generator/SecureRandomGenerator.java
@@ -1,9 +1,18 @@
 package interface_adapter.crypto.random_generator;
 
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 public class SecureRandomGenerator implements RandomGenerator {
-    private static final SecureRandom random = new SecureRandom();
+    private static SecureRandom random;
+
+    static {
+        try {
+            random = SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            random = new SecureRandom();
+        }
+    }
 
     public byte[] getRandomBytes(int size) {
         byte[] bytes = new byte[size];


### PR DESCRIPTION
getInstanceStrong is at least as "secure" as the default new SecureRandom(), so use it if available. The official docs say that every Java platform is required to implement at least one such strong instance, so it should always be availble. Argon2 too slow to run, so reduce 1 GiB -> 256 MiB.