### PR TITLE
Implement removeVaultItem

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -6,7 +6,7 @@ import java.awt.CardLayout;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 
-import data_access.authentication.FireStoreUserDataAccessObject;
+import data_access.FireStoreUserDataAccessObject;
 import data_access.authentication.FirebaseAuthRepository;
 import interface_adapter.net.http.CommonHttpClient;
 import interface_adapter.net.http.HttpClient;

--- a/src/main/java/data_access/FireStoreUserDataAccessObject.java
+++ b/src/main/java/data_access/FireStoreUserDataAccessObject.java
@@ -80,7 +80,7 @@ public class FireStoreUserDataAccessObject implements UserRepository {
             final CloudVault vault = getVault(jsonResponse);
             final RemoteAuth auth = new RemoteAuth(loginResponse);
 
-            return new CloudUser(email, vault, auth);
+            return new CloudUser(email, password, vault, auth);
         }
         catch (HttpRequestException httpRequestException) {
             throw new AuthException(AuthErrorReason.REQUEST_ERROR, httpRequestException.getMessage());
@@ -94,7 +94,7 @@ public class FireStoreUserDataAccessObject implements UserRepository {
         final RemoteAuth auth = new RemoteAuth(loginResponse);
         createUserDocument(loginResponse);
 
-        return new CloudUser(email, new CloudVault(new ArrayList<>()), auth);
+        return new CloudUser(email, password, new CloudVault(new ArrayList<>()), auth);
     }
 
     @Override

--- a/src/main/java/data_access/FireStoreUserDataAccessObject.java
+++ b/src/main/java/data_access/FireStoreUserDataAccessObject.java
@@ -1,7 +1,8 @@
-package data_access.authentication;
+package data_access;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
@@ -104,6 +105,23 @@ public class FireStoreUserDataAccessObject implements UserRepository {
 
         user.getVault().addItem(item);
 
+        addAllItemsToVault(cloudUser);
+    }
+
+    @Override
+    public void removeVaultItem(AbstractUser user, AbstractVaultItem item) throws AuthException {
+        if (!(user instanceof CloudUser cloudUser)) {
+            throw new IllegalArgumentException("User must be a CloudUser.");
+        }
+
+        final List<AbstractVaultItem> vaultItems = user.getVault().getItems();
+        vaultItems.remove(item);
+        user.getVault().setItems(vaultItems);
+
+        addAllItemsToVault(cloudUser);
+    }
+
+    private void addAllItemsToVault(CloudUser cloudUser) throws AuthException {
         if (!cloudUser.getRemoteAuth().isRefreshTokenValid()) {
             final AuthResponse newAuth = authRepository.refreshToken(cloudUser.getRemoteAuth().getRefreshToken());
             cloudUser.setRemoteAuth(new RemoteAuth(newAuth));

--- a/src/main/java/entity/AbstractUser.java
+++ b/src/main/java/entity/AbstractUser.java
@@ -6,15 +6,21 @@ package entity;
 
 public abstract class AbstractUser {
     private String email;
+    private final String password;
     private AbstractVault vault;
 
-    public AbstractUser(String email, AbstractVault vault) {
+    public AbstractUser(String email, String password, AbstractVault vault) {
         this.email = email;
+        this.password = password;
         this.vault = vault;
     }
 
     public String getEmail() {
         return email;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     public void setEmail(String username) {

--- a/src/main/java/entity/AbstractVault.java
+++ b/src/main/java/entity/AbstractVault.java
@@ -62,5 +62,4 @@ public abstract class AbstractVault {
             }
         }
     }
-
 }

--- a/src/main/java/entity/CloudUser.java
+++ b/src/main/java/entity/CloudUser.java
@@ -10,10 +10,11 @@ public class CloudUser extends AbstractUser {
 
     public CloudUser(
             String email,
+            String password,
             AbstractVault vault,
             RemoteAuth auth
     ) {
-        super(email, vault);
+        super(email, password, vault);
         this.remoteAuth = auth;
     }
 

--- a/src/main/java/entity/CommonUser.java
+++ b/src/main/java/entity/CommonUser.java
@@ -5,7 +5,7 @@ package entity;
  */
 public class CommonUser extends AbstractUser {
 
-    public CommonUser(String username, AbstractVault vault) {
-        super(username, vault);
+    public CommonUser(String username, String password, AbstractVault vault) {
+        super(username, password, vault);
     }
 }

--- a/src/main/java/entity/CommonUser.java
+++ b/src/main/java/entity/CommonUser.java
@@ -5,7 +5,7 @@ package entity;
  */
 public class CommonUser extends AbstractUser {
 
-    public CommonUser(String username, String password, AbstractVault vault) {
-        super(username, password, vault);
+    public CommonUser(String email, String password, AbstractVault vault) {
+        super(email, password, vault);
     }
 }

--- a/src/main/java/repository/UserRepository.java
+++ b/src/main/java/repository/UserRepository.java
@@ -36,4 +36,13 @@ public interface UserRepository {
      * @throws AuthException If the item could not be added to the user's vault.
      */
     void addVaultItem(AbstractUser user, AbstractVaultItem item) throws AuthException;
+
+    /**
+     * Remove an item from the user's vault.
+     *
+     * @param user The user to remove the item from.
+     * @param item The item to remove from the user's vault.
+     * @throws AuthException If the item could not be removed from the user's vault.
+     */
+    void removeVaultItem(AbstractUser user, AbstractVaultItem item) throws AuthException;
 }

--- a/src/main/java/views/HomeView.java
+++ b/src/main/java/views/HomeView.java
@@ -11,7 +11,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
-import data_access.authentication.FireStoreUserDataAccessObject;
+import data_access.FireStoreUserDataAccessObject;
 import entity.AbstractVaultItem;
 import service.ViewManagerModel;
 import service.home.interface_adapter.HomeController;

--- a/src/test/java/entity/CloudUserTest.java
+++ b/src/test/java/entity/CloudUserTest.java
@@ -1,0 +1,38 @@
+package entity;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import interface_adapter.net.auth.RemoteAuth;
+import org.junit.jupiter.api.Test;
+
+public class CloudUserTest {
+    private static final String title = "Google";
+    private static final String userAndGoogleEmail = "doorkey@gmail.com";
+    private static final String userPassword = "mySecureMasterPa@@5d";
+    private static final String password = "pa55w0rD";
+    private static final String url = "https://google.com";
+    private static final RemoteAuth remoteAuth = new RemoteAuth(
+            "idToken",
+            "refreshToken",
+            "localId",
+            60
+    );
+    private final List<AbstractVaultItem> items = new ArrayList<>();
+
+    @Test
+    void testCommonUser() {
+        PasswordVaultItem item = new PasswordVaultItem(title, userAndGoogleEmail, password, url);
+        items.add(item);
+
+        AbstractVault vault = new LocalVault(items);
+        CloudUser user = new CloudUser(userAndGoogleEmail, userPassword, vault, remoteAuth);
+        assertTrue(user.getEmail().equals(userAndGoogleEmail));
+        assertTrue(user.getVault() == vault);
+        assertTrue(user.getPassword().equals(userPassword));
+        assertTrue(user.getVault().getItems().get(0) == item);
+        assertTrue(user.getRemoteAuth() == remoteAuth);
+    }
+}

--- a/src/test/java/entity/CommonUserTest.java
+++ b/src/test/java/entity/CommonUserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 public class CommonUserTest {
     private static final String title = "Google";
     private static final String email = "doorkey@gmail.com";
+    private static final String userPassword = "mySecureMasterPa@@5d";
     private static final String password = "pa55w0rD";
     private static final String url = "https://google.com";
     private final List<AbstractVaultItem> items = new ArrayList<>();
@@ -20,9 +21,10 @@ public class CommonUserTest {
         items.add(item);
 
         AbstractVault vault = new LocalVault(items);
-        AbstractUser user = new CommonUser(email, vault);
+        AbstractUser user = new CommonUser(email, userPassword, vault);
         assertTrue(user.getEmail().equals(email));
         assertTrue(user.getVault() == vault);
+        assertTrue(user.getPassword().equals(userPassword));
         assertTrue(user.getVault().getItems().get(0) == item);
     }
 }

--- a/src/test/java/mock/MockUserRepository.java
+++ b/src/test/java/mock/MockUserRepository.java
@@ -10,6 +10,7 @@ import repository.UserRepository;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -24,7 +25,7 @@ public class MockUserRepository implements UserRepository {
         if (users.containsKey(email)) {
             throw new AuthException(AuthErrorReason.EMAIL_EXISTS, "User already exists.");
         }
-        AbstractUser newUser = new CommonUser(email, new LocalVault(new ArrayList<>()));
+        AbstractUser newUser = new CommonUser(email, password, new LocalVault(new ArrayList<>()));
         users.put(email, newUser);
         passwords.put(email, password);
         return newUser;
@@ -41,5 +42,12 @@ public class MockUserRepository implements UserRepository {
     @Override
     public void addVaultItem(AbstractUser user, AbstractVaultItem item) {
         user.getVault().addItem(item);
+    }
+
+    @Override
+    public void removeVaultItem(AbstractUser user, AbstractVaultItem item) {
+        List<AbstractVaultItem> items = user.getVault().getItems();
+        items.remove(item);
+        user.getVault().setItems(items);
     }
 }


### PR DESCRIPTION
 - Adds removeVaultItem to the UserRepository interface. 
 - Implements removeVaultItem for Firestore.
 - Adds 'password' field to AbstractUser, which may be needed for decryption in the future PRs.
 - Replaces 'username' with 'email' in CommonUser.
 - Adds a test for CloudUser.