### PR TITLE
build-jar workflow: don't run unit tests

### DIFF
--- a/.github/workflows/build-jar.yml
+++ b/.github/workflows/build-jar.yml
@@ -21,7 +21,6 @@ jobs:
         cache: maven
     - name: Build .jar
       run: |
-        mvn clean test
         mvn clean compile assembly:single
         mv target/doorkey-0.1-dev-jar-with-dependencies.jar doorkey.jar
 


### PR DESCRIPTION
It's already done in another workflow